### PR TITLE
Add note about GNU make

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ With dependencies installed and repo cloned:
 
 `make install` 
 
+Note that GNU make (gmake on BSD) is required.
+
 ## Usage
 
 Click and drag anywhere on the screen to make a selection, or screenshot a window by clicking on it.


### PR DESCRIPTION
When building xsnip on OpenBSD (and I assume other BSDs as well) BSD make gives the following error:

`make: don't know how to make %.c (prerequisite of: %.o)`

GNU make works better.

I also suggest you rename the Makefile to GNUmakefile.