### PR TITLE
Be more generic in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
-CC=gcc
-CFLAGS=-g -I. -lX11 -lpng
+X11_CFLAGS != pkg-config --cflags x11
+X11_LIBS != pkg-config --libs x11
+
+LIBPNG_CFLAGS != pkg-config --cflags libpng
+LIBPNG_LIBS != pkg-config --libs libpng
+
+CC?=gcc
+CFLAGS=-g ${X11_CFLAGS} ${LIBPNG_CFLAGS}
+LIBS=${X11_LIBS} ${LIBPNG_LIBS}
 DEPS=config.h 
-OBJ=xsnip.c
+OBJ=xsnip.o
 
 prefix=/usr/local
 exec_prefix=${prefix}
@@ -11,7 +18,7 @@ bindir=${exec_prefix}/bin
 	$(CC) -c -o $@ $< $(CFLAGS)
 
 xsnip: $(OBJ)
-	$(CC) -o $@ $^ $(CFLAGS)
+	$(CC) -o $@ $^ $(LIBS)
 
 install:
 	cp xsnip $(bindir)

--- a/xsnip.c
+++ b/xsnip.c
@@ -156,7 +156,7 @@ int main(int argc, char** argv) {
 
 	display = XOpenDisplay(NULL);
 	if(!display) 
-		exit_clean("Failed to open X display\n");
+		return exit_clean("Failed to open X display\n");
 	root = DefaultRootWindow(display);
 
 	// Query windows for hover selection. This may result in undefined


### PR DESCRIPTION
This PR contains:
- a fix for a coredump : when `XOpenDisplay()` error out, the call to `exit_clean()` doesn't terminate the program
- make Makefile more generic
  - detect X11 and png libraries using `pkg-config` tool
  - permit override of CC from command-line (by using `make CC=clang` for example)

Fixes #6 